### PR TITLE
Changing the master-slave language

### DIFF
--- a/requirement/gnb_logs_new.py
+++ b/requirement/gnb_logs_new.py
@@ -521,7 +521,7 @@ def all_nodes_fnames(nodes):
 		
 def router_fnames(node,nodes):		 #??
 	#host是一个全球变量，所以取log的思路是先去CU里面，存一堆VM的名字到host里面，然后一个个去登陆，取log
-	#再clear，然后把DU里面的各个abil的master和slave存到host里面，然后一个个登陆并去取log
+	#再clear，然后把DU里面的各个abil的main和subordinate存到host里面，然后一个个登陆并去取log
 	names = node['name'] + "_* "
 	for i in range(0, len(hosts)):
 		if nodes[i]:


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.